### PR TITLE
ci: change npm publish workflow to match org process

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,6 +4,7 @@ env:
   APP_NAME: hc-spin-rust-utils
   MACOSX_DEPLOYMENT_TARGET: "10.13"
 "on":
+  workflow_call:
   pull_request:
     branches:
       - main

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,21 +3,7 @@ env:
   DEBUG: napi:*
   APP_NAME: hc-spin-rust-utils
   MACOSX_DEPLOYMENT_TARGET: "10.13"
-permissions:
-  contents: write
-  id-token: write
 "on":
-  push:
-    branches:
-      - main
-    tags-ignore:
-      - "**"
-    paths-ignore:
-      - "**/*.md"
-      - LICENSE
-      - "**/*.gitignore"
-      - .editorconfig
-      - docs/**
   pull_request:
     branches:
       - main
@@ -224,45 +210,3 @@ jobs:
             yarn test
             ls -la
 
-  publish:
-    name: Publish
-    runs-on: ubuntu-latest
-    needs:
-      - test-macOS-windows-binding
-      - test-linux-x64-gnu-binding
-      - test-linux-aarch64-gnu-binding
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
-          cache: yarn
-      - name: Install dependencies
-        run: yarn install
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-      - name: Move artifacts
-        run: yarn artifacts
-      - name: List packages
-        run: ls -R ./npm
-        shell: bash
-      - name: Publish
-        run: |
-          npm config set provenance true
-          if git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+$";
-          then
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-            npm publish --access public
-          elif git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+";
-          then
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-            npm publish --tag dev --access public
-          else
-            echo "Not a release, skipping publish"
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,7 @@ env:
   pull_request:
     branches:
       - main
+      - main-*
     paths-ignore:
       - "**/*.md"
       - LICENSE

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -65,13 +65,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup node
         uses: actions/setup-node@v4
-        if: ${{ !matrix.settings.docker }}
         with:
           node-version: 18
           cache: yarn
       - name: Install
         uses: dtolnay/rust-toolchain@stable
-        if: ${{ !matrix.settings.docker }}
         with:
           toolchain: stable
           targets: ${{ matrix.settings.target }}
@@ -110,16 +108,8 @@ jobs:
           node-version: 18
           cache: yarn
           architecture: x86
-      - name: Build in docker
-        uses: addnab/docker-run-action@v3
-        if: ${{ matrix.settings.docker }}
-        with:
-          image: ${{ matrix.settings.docker }}
-          options: "--user 0:0 -v ${{ github.workspace }}/.cargo-cache/git/db:/usr/local/cargo/git/db -v ${{ github.workspace }}/.cargo/registry/cache:/usr/local/cargo/registry/cache -v ${{ github.workspace }}/.cargo/registry/index:/usr/local/cargo/registry/index -v ${{ github.workspace }}:/build -w /build"
-          run: ${{ matrix.settings.build }}
       - name: Build
         run: ${{ matrix.settings.build }}
-        if: ${{ !matrix.settings.docker }}
         shell: bash
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   prepare:
-    uses: holochain/actions/.github/workflows/nodejs-prepare-release.yml@split-nodejs-workflow-into-actions
+    uses: holochain/actions/.github/workflows/nodejs-prepare-release.yml@v1.14.0
     with:
       cliff_config_url: 'https://raw.githubusercontent.com/holochain/release-integration/refs/heads/main/pre-1.0-cliff.toml'
       force_version: ${{ inputs.version }}

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,20 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Exact version to release (e.g. 1.2.3). Leave empty to infer from commits.'
+        required: false
+        type: string
+
+jobs:
+  prepare:
+    uses: holochain/actions/.github/workflows/nodejs-prepare-release.yml@split-nodejs-workflow-into-actions
+    with:
+      cliff_config_url: 'https://raw.githubusercontent.com/holochain/release-integration/refs/heads/main/pre-1.0-cliff.toml'
+      force_version: ${{ inputs.version }}
+      package_manager: yarn
+      install_deps: true
+    secrets:
+      GH_TOKEN: ${{ secrets.HRA2_GITHUB_TOKEN }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           path: artifacts
 
-      - uses: holochain/actions/nodejs-setup@split-nodejs-workflow-into-actions
+      - uses: holochain/actions/nodejs-setup@v1.14.0
         with:
           package_manager: yarn
           cache: false
@@ -50,4 +50,4 @@ jobs:
       - name: Assemble artifacts
         run: yarn artifacts
 
-      - uses: holochain/actions/nodejs-publish@split-nodejs-workflow-into-actions
+      - uses: holochain/actions/nodejs-publish@v1.14.0

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -50,6 +50,11 @@ jobs:
       - name: Assemble artifacts
         run: yarn artifacts
 
+      - name: Configure npm auth
+        run: npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - uses: holochain/actions/nodejs-publish@split-nodejs-workflow-into-actions
         with:
           npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,55 @@
+name: Publish Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      is-release: ${{ steps.label.outputs.result }}
+    steps:
+      - name: Check for hra-release label on merged PR
+        id: label
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          RESULT=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls \
+            --jq 'any(.[].labels[].name; . == "hra-release")' 2>/dev/null || echo "false")
+          echo "result=$RESULT" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: check
+    if: needs.check.outputs.is-release == 'true'
+    uses: ./.github/workflows/CI.yml
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - uses: holochain/actions/nodejs-setup@split-nodejs-workflow-into-actions
+        with:
+          package_manager: yarn
+          cache: false
+          install_deps: true
+
+      - name: Assemble artifacts
+        run: yarn artifacts
+
+      - uses: holochain/actions/nodejs-publish@split-nodejs-workflow-into-actions
+        with:
+          npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -50,11 +50,4 @@ jobs:
       - name: Assemble artifacts
         run: yarn artifacts
 
-      - name: Configure npm auth
-        run: npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - uses: holochain/actions/nodejs-publish@split-nodejs-workflow-into-actions
-        with:
-          npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main, main-*]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -2,7 +2,7 @@ name: Publish Release
 
 on:
   push:
-    branches: [main]
+    branches: [main, main-*]
 
 jobs:
   check:

--- a/README.md
+++ b/README.md
@@ -9,15 +9,22 @@ At the time of writing it contains two main pieces:
 - A `ZomeCallSigner` object that connects to a running instance of lair keystore and exposes a method `signZomeCall` to have lair sign zome calls for a specified public key.
 
 
+## Supporting a new Holochain version
+
+Once a new version of Holochain is released, support for it can be added by following these steps:
+
+1. Update the crates in `Cargo.toml` as necessary and make any required changes in case of compilation errors. Do NOT change the package version in package.json. This will be done automatically when creating a new release.
+2. Test the package locally by
+    1. Building it: `npm run build`
+    2. Linking it globally with yarn: `yarn link`
+    3. Inside a local `hc-spin` repository, use the linked local package: `yarn link @holochain/hc-spin-rust-utils` and test that hc-spin works and zome calls succeed (you may want to unlink it again after testing with `yarn unlink @holochain/hc-spin-rust-utils`).
+3. If testing succeeds, commit the changes and make a PR to `main` or `main-xx` where `xx` is the Holochain version branch, for example `main-06` contains new Holochain `v0.6.x` versions. This will trigger a CI test run that builds the package for all platforms but does not publish it.
 
 ## Release process
 
 To release a new version of `@holochain/hc-spin-rust-utils`, you may proceed as follows:
 
-1. Update the crates in Cargo.toml as necessary and make any required changes in case of compilation errors. Do NOT change the package version in package.json. This will be done automatically in step 4 as part of the `npm version` command.
-2. (optional but recommended) Test the package locally by
-    1. Building it: `npm run build`
-    2. Linking it globally with yarn: `yarn link`
-    3. Inside a local `hc-spin` repository, use the linked local package: `yarn link @holochain/hc-spin-rust-utils` and test that hc-spin works and zome calls succeed (you may want to unlink it again after testing with `yarn unlink @holochain/hc-spin-rust-utils`).
-3. If testing succeeds, commit the changes and make a PR to main. This will trigger a CI test run that builds the package for all platforms but does not publish it.
-4. If the CI run from step 3 succeeds, merge the PR. Then create a new version commit for the desired version directly on the main branch, using the associated npm command: `npm version [desired version]`, e.g. `npm version 0.700.0` and push to main. This will trigger the CI workflow again which will this time recognize from the commit that it is a version release and automatically publish the built packages to npm. The latter requires that a valid `NPM_TOKEN` has been added as a repository secret.
+1. Trigger the [Prepare Release](https://github.com/holochain/hc-spin-rust-utils/actions/workflows/release-prepare.yml) action with the desired new version number on the corresponding branch (`main` for the Holochain `main` branch and `main-xx` for older versions).
+2. This will bump the versions, generate a changelog, and open a PR for these changes.
+3. Review and manually edit the PR on the working branch where required.
+4. Merge the PR with a rebase-merge. This will trigger the [Publish Release](https://github.com/holochain/hc-spin-rust-utils/actions/workflows/release-publish.yml) workflow which will build the packages and publish them to NPM via Trusted Publishers and to GitHub as a release with artifacts.

--- a/README.md
+++ b/README.md
@@ -21,8 +21,3 @@ To release a new version of `@holochain/hc-spin-rust-utils`, you may proceed as 
     3. Inside a local `hc-spin` repository, use the linked local package: `yarn link @holochain/hc-spin-rust-utils` and test that hc-spin works and zome calls succeed (you may want to unlink it again after testing with `yarn unlink @holochain/hc-spin-rust-utils`).
 3. If testing succeeds, commit the changes and make a PR to main. This will trigger a CI test run that builds the package for all platforms but does not publish it.
 4. If the CI run from step 3 succeeds, merge the PR. Then create a new version commit for the desired version directly on the main branch, using the associated npm command: `npm version [desired version]`, e.g. `npm version 0.700.0` and push to main. This will trigger the CI workflow again which will this time recognize from the commit that it is a version release and automatically publish the built packages to npm. The latter requires that a valid `NPM_TOKEN` has been added as a repository secret.
-
-
-## NPM token
-
-The npm token used to publish the packages to npm from CI is currently stored as a repository secret (`NPM_TOKEN`) in this repository. If the token expires, a new token needs to be created on npmjs.org and the content of the repository secret replaced with the newly generated token.

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/hc-spin-rust-utils-darwin-arm64",
-  "version": "0.700.0-dev.0",
+  "version": "0.700.0-dev.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/holochain/hc-spin-rust-utils",

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/hc-spin-rust-utils-darwin-x64",
-  "version": "0.700.0-dev.0",
+  "version": "0.700.0-dev.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/holochain/hc-spin-rust-utils",

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/hc-spin-rust-utils-linux-arm64-gnu",
-  "version": "0.700.0-dev.0",
+  "version": "0.700.0-dev.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/holochain/hc-spin-rust-utils",

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/hc-spin-rust-utils-linux-x64-gnu",
-  "version": "0.700.0-dev.0",
+  "version": "0.700.0-dev.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/holochain/hc-spin-rust-utils",

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/hc-spin-rust-utils-win32-x64-msvc",
-  "version": "0.700.0-dev.0",
+  "version": "0.700.0-dev.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/holochain/hc-spin-rust-utils",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/holochain/hc-spin-rust-utils"
   },
-  "version": "0.700.0-dev.0",
+  "version": "0.700.0-dev.1",
   "main": "index.js",
   "types": "index.d.ts",
   "napi": {


### PR DESCRIPTION
The publish workflow has been tested and it worked successfully: https://github.com/holochain/hc-spin-rust-utils/actions/runs/27558394902

However, the prepare workflow cannot be tested until it is merged to the default branch as it uses `workflow_dispatch`.

This PR uses the actions and the reusable prepare workflow from https://github.com/holochain/actions.


Some key differences are:

1. The release process is now triggered on a manual dispatch of the new prepare release workflow which opens a PR with the required changelog and version bump changes.
2. Once that PR is merged (preferably a rebase-merge) then the tagging and release of all the packages is triggered automatically and should behave as before before without having to manually create a release tag.
3. The changelog is now generated automatically from the conventional commits via `git-cliff`.
4. The releases are published to NPM via Trusted Publishers instead of the token.
5. The version has been bumped to `0.700.0-dev.1` as that version was used for testing and so even though it has been deprecated and unpublished, it cannot be reused.

I also removed the docker build logic as it was dependant on a matrix entry that didn't exist (I assume it has been removed)