### PR TITLE
docs: add missing changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,174 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## \[[0.700.0-dev.0](https://github.com/holochain/hc-spin-rust-utils/compare/v0.600.0...v0.700.0-dev.0)\] - 2026-01-13
+
+### Features
+
+- Bump to holochain 0.7.0-dev.7 by @matthme
+
+### Documentation
+
+- Add maintenance instructions by @matthme
+
+### Other Changes
+
+- Merge pull request #8 from holochain/bump-0.7.0-dev by @matthme in [#8](https://github.com/holochain/hc-spin-rust-utils/pull/8)
+- Merge pull request #7 from holochain/docs/maintenance-instructions by @matthme in [#7](https://github.com/holochain/hc-spin-rust-utils/pull/7)
+
+## \[[0.600.0](https://github.com/holochain/hc-spin-rust-utils/compare/v0.600.0-dev.0...v0.600.0)\] - 2025-11-20
+
+### Other Changes
+
+- Update to holochain 0.6.0 by @veeso
+
+### First-time Contributors
+
+- @veeso made their first contribution
+
+## \[[0.600.0-dev.0](https://github.com/holochain/hc-spin-rust-utils/compare/v0.500.1...v0.600.0-dev.0)\] - 2025-10-02
+
+### Features
+
+- Update to holochain 0.6.0-dev.24 by @matthme
+
+### Miscellaneous Tasks
+
+- Switch to dev tag by @matthme
+
+### Documentation
+
+- Update readme by @matthme
+
+## \[[0.500.1](https://github.com/holochain/hc-spin-rust-utils/compare/v0.500.0...v0.500.1)\] - 2025-08-23
+
+### Features
+
+- Add arm64 target by @matthme
+
+### Other Changes
+
+- Merge pull request #2 from holochain/feat/add-arm64-target by @matthme in [#2](https://github.com/holochain/hc-spin-rust-utils/pull/2)
+
+## \[[0.500.0](https://github.com/holochain/hc-spin-rust-utils/compare/v0.500.0-rc.1...v0.500.0)\] - 2025-04-22
+
+### Other Changes
+
+- Bump to holochain 0.5.0 by @matthme
+
+## \[[0.500.0-rc.1](https://github.com/holochain/hc-spin-rust-utils/compare/v0.500.0-rc.0...v0.500.0-rc.1)\] - 2025-04-15
+
+### Other Changes
+
+- Bump holochain dependencies by @matthme
+
+## \[[0.500.0-rc.0](https://github.com/holochain/hc-spin-rust-utils/compare/v0.500.0-dev.1...v0.500.0-rc.0)\] - 2025-04-07
+
+### Bug Fixes
+
+- Fix passphrase type by @matthme
+
+### Other Changes
+
+- Remove unused dependency by @matthme
+- Bump holochain to 0.5.0-rc.0 by @matthme
+
+## \[[0.500.0-dev.1](https://github.com/holochain/hc-spin-rust-utils/compare/v0.500.0-dev.0...v0.500.0-dev.1)\] - 2025-03-05
+
+### Other Changes
+
+- Bump download-artifact action by @matthme
+- Bump upload-artifact action by @matthme
+- Bump holochain crates by @matthme
+
+## \[[0.500.0-dev.0](https://github.com/holochain/hc-spin-rust-utils/compare/v0.400.0-dev.2...v0.500.0-dev.0)\] - 2024-11-26
+
+### Bug Fixes
+
+- Fix version numbers by @matthme
+
+### Other Changes
+
+- Undo version by @matthme
+- Merge pull request #1 from holochain/feat/new-zome-call-signing-logic by @matthme in [#1](https://github.com/holochain/hc-spin-rust-utils/pull/1)
+- Add Cargo.lock by @matthme
+- Switched to new zome call signing logic by @matthme
+
+## \[[0.400.0-dev.2](https://github.com/holochain/hc-spin-rust-utils/compare/v0.400.0-dev.1...v0.400.0-dev.2)\] - 2024-05-10
+
+### Bug Fixes
+
+- Fixed target x64 by @matthme
+
+### Other Changes
+
+- 0.400.0-dev.2 by @matthme
+
+## \[[0.400.0-dev.1](https://github.com/holochain/hc-spin-rust-utils/compare/v0.300.1...v0.400.0-dev.1)\] - 2024-05-09
+
+### Other Changes
+
+- 0.400.0-dev.1 by @matthme
+- Switched to dev version number by @matthme
+- Try out normal macos runner by @matthme
+- 0.400.0 by @matthme
+- Bumped to holochain 0.4 by @matthme
+
+## \[[0.300.1](https://github.com/holochain/hc-spin-rust-utils/compare/v0.200.3...v0.300.1)\] - 2024-02-07
+
+### Bug Fixes
+
+- Fixed types, removed sodoken dependency by @matthme
+
+### Other Changes
+
+- 0.300.1 by @matthme
+- Bumped to holochain 0.3 by @matthme
+
+## \[[0.200.3](https://github.com/holochain/hc-spin-rust-utils/compare/v0.100.2...v0.200.3)\] - 2024-01-29
+
+### Other Changes
+
+- 0.200.3 by @matthme
+- Trying M1 runner to build tx5 by @matthme
+
+## \[[0.100.2](https://github.com/holochain/hc-spin-rust-utils/compare/v0.200.2...v0.100.2)\] - 2024-01-29
+
+### Other Changes
+
+- Added darwin aarch64 target by @matthme
+
+## \[[0.200.2](https://github.com/holochain/hc-spin-rust-utils/commits/v0.200.2)\] - 2024-01-23
+
+### Other Changes
+
+- 0.200.2 by @matthme
+- 0.200.1 by @matthme
+- Back down to 0.200.0 by @matthme
+- Added repository info to package.json files in npm folder by @matthme
+- 0.200.1 by @matthme
+- Added repository to package.json by @matthme
+- Removed failing test by @matthme
+- Removed docker, added Go installation step by @matthme
+- Switched to wget by @matthme
+- Changed go installation command by @matthme
+- Added go installation step by @matthme
+- Removed unnecessary dependencies by @matthme
+- Openssl fix by @matthme
+- Changed installation order by @matthme
+- Added pkg-config dep by @matthme
+- Added -y flag by @matthme
+- Added libssl-dev installation to matrix build command by @matthme
+- Moved libssl-dev installation step to right place by @matthme
+- Installing libssl-dev on Ubuntu runner by @matthme
+- Removed packagemanager field by @matthme
+- Initial commit by @matthme
+
+### First-time Contributors
+
+- @matthme made their first contribution
+
+<!-- generated by git-cliff -->


### PR DESCRIPTION
git-cliff requires that the changelog already exists so it can prepend to it.