### PR TITLE
ci: use standard GitHub token with contents and PR write permissions

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -8,6 +8,10 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   prepare:
     uses: holochain/actions/.github/workflows/nodejs-prepare-release.yml@v1.14.0
@@ -17,4 +21,4 @@ jobs:
       package_manager: yarn
       install_deps: true
     secrets:
-      GH_TOKEN: ${{ secrets.HRA2_GITHUB_TOKEN }}
+      GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
I copied this workflow from the `hc-spin` repo but this repo doesn't have the `HRA2_GITHUB_TOKEN` secret :facepalm:

This PR just uses the normal GITHUB_TOKEN with permissions set to write the contents (bump the version) and write PRs (open release PR).