### PR TITLE
fix: migrate napi config to v3 targets format

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
   "main": "index.js",
   "types": "index.d.ts",
   "napi": {
-    "name": "hc-spin-rust-utils",
-    "triples": {
-      "additional": [
-        "aarch64-apple-darwin",
-        "aarch64-unknown-linux-gnu"
-      ]
-    }
+    "binaryName": "hc-spin-rust-utils",
+    "targets": [
+      "x86_64-apple-darwin",
+      "x86_64-pc-windows-msvc",
+      "x86_64-unknown-linux-gnu",
+      "aarch64-apple-darwin",
+      "aarch64-unknown-linux-gnu"
+    ]
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
## Summary
- The `0.700.0-dev.3` publish failed at the `napi artifacts` step with `No dist dir found for .../hc-spin-rust-utils.darwin-x64.node` ([run](https://github.com/holochain/hc-spin-rust-utils/actions/runs/28232897686/job/83641885992)).
- Root cause: the `@napi-rs/cli` bump to v3 changed how the legacy `napi.triples` config is read. In v2 the default host targets were implicit; in v3 they're only included when `triples.defaults` is explicitly set. With just `triples.additional` configured, `napi artifacts` only resolved the two aarch64 targets and failed on the three x86_64 binaries.
- Migrated `package.json` to the v3 `binaryName` + `targets` format, listing all five build-matrix targets (`x86_64-apple-darwin`, `x86_64-pc-windows-msvc`, `x86_64-unknown-linux-gnu`, `aarch64-apple-darwin`, `aarch64-unknown-linux-gnu`). This also clears the `[DEPRECATED]` warnings for `napi.name`/`napi.triples`.
- Note: simply adding `"defaults": true` would not work — v3's default target set already contains `aarch64-apple-darwin`, which is also in `additional`, so it would error with `Duplicate targets are not allowed`.

## Verification
- Reproduced the publish step locally with dummy `.node` artifacts for all five targets: with the fix, `napi artifacts` reads all five, writes each into its `npm/<platform>/` dir, and exits 0 with no deprecation warnings.