### PR TITLE
ci: add `ci_pass` job as required by repo settings

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -211,3 +211,17 @@ jobs:
             set -e
             yarn test
             ls -la
+
+  ci_pass:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test-macOS-windows-binding
+      - test-linux-x64-gnu-binding
+      - test-linux-aarch64-gnu-binding
+    steps:
+      - name: check status
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
The `ci_pass` job was recently added as a required job to this repo's settings.