### PR TITLE
test: load native binding in CI smoke test

### DIFF
--- a/__test__/index.spec.mjs
+++ b/__test__/index.spec.mjs
@@ -1,5 +1,9 @@
 import test from 'ava'
+import { unpackAndSaveWebhapp, ZomeCallSigner } from '../index.js'
 
-test('blank', (t) => {
-  t.is(true, true);
+test('native binding loads and exposes the public API', (t) => {
+  t.is(typeof unpackAndSaveWebhapp, 'function')
+  t.is(typeof ZomeCallSigner, 'function')
+  t.is(typeof ZomeCallSigner.connect, 'function')
+  t.is(typeof ZomeCallSigner.prototype.signZomeCall, 'function')
 })


### PR DESCRIPTION
## Summary

- replace the placeholder AVA test with a native-binding smoke test
- import the package entry point so the N-API `.node` artifact must actually load
- assert the two public exports and the signer methods used by consumers

The six binding-test jobs already download each target artifact, but the old test never imported `index.js`; a missing or broken artifact therefore passed. This test exercises the loader before checking the public API, so platform and Node-version matrix jobs now fail when the handoff or native load is broken.

## Validation

- `git diff --check`
- `npm test` without a built artifact fails at the intended loader boundary (`Cannot find module ...win32-x64-msvc`), proving the test no longer passes when the binding is absent
- Full native build/test validation is delegated to the repository CI matrix, which supplies the target `.node` artifact

Fixes #43
